### PR TITLE
Make thread rng an optional feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ categories = ["algorithms"]
 license = "MIT"
 
 [features]
+default = ["thread_rng"]
+
 # The thread_rng feature requires the rand dependency
 thread_rng = ["rand"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["random", "rng"]
 categories = ["algorithms"]
 license = "MIT"
 
+[features]
+thread = ["rand"]
+
 [dependencies]
 rand_core = "0.5"
-rand = "0.7"
+rand = {version = "0.7", optional = true}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ categories = ["algorithms"]
 license = "MIT"
 
 [features]
-thread = ["rand"]
+# The thread_rng feature requires the rand dependency
+thread_rng = ["rand"]
 
 [dependencies]
 rand_core = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,5 @@ categories = ["algorithms"]
 license = "MIT"
 
 [dependencies]
-rand = "0.6"
-rand_core = "0.3"
+rand_core = "0.5"
+rand = "0.7"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -32,3 +32,6 @@ jobs:
 
       - script: cargo test -v 2>&1
         displayName: run test
+
+      - script: cargo test -v --features thread 2>&1
+        displayName: run test with thread features

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,5 +33,5 @@ jobs:
       - script: cargo test -v 2>&1
         displayName: run test
 
-      - script: cargo test -v --features thread 2>&1
-        displayName: run test with thread features
+      - script: cargo test -v --features thread_rng 2>&1
+        displayName: run tests with thread_rng feature

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -30,8 +30,8 @@ jobs:
           echo '##vso[task.setvariable variable=PATH;]%PATH%;%USERPROFILE%\.cargo\bin'
         displayName: install rustup on Windows
 
-      - script: cargo test -v 2>&1
-        displayName: run test
+      - script: cargo test -v --no-default-features 2>&1
+        displayName: run tests without default features
 
       - script: cargo test -v --features thread_rng 2>&1
         displayName: run tests with thread_rng feature

--- a/ci/job.yml
+++ b/ci/job.yml
@@ -20,3 +20,5 @@ jobs:
         displayName: install rustup
       - script: cargo test --verbose
         displayName: run test
+      - script: cargo test -v --features thread
+        displayName: run test with thread features

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,13 +12,13 @@
 
 mod packed;
 mod sfmt;
-#[cfg(feature = "thread")]
+#[cfg(feature = "thread_rng")]
 mod thread_rng;
 
 use rand_core::{impls, Error, RngCore, SeedableRng};
 
 use self::packed::*;
-#[cfg(feature = "thread")]
+#[cfg(feature = "thread_rng")]
 pub use self::thread_rng::{thread_rng, ThreadRng};
 
 /// State of SFMT

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! [stable SIMD]: https://github.com/rust-lang/rfcs/blob/master/text/2325-stable-simd.md
 //!
 //! ```
-//! use rand::{Rng, FromEntropy};
+//! use rand::prelude::*;
 //! let mut rng = sfmt::SFMT::from_entropy();
 //! let r = rng.gen::<u32>();
 //! println!("random u32 number = {}", r);
@@ -58,7 +58,7 @@ impl SeedableRng for SFMT {
 
     fn from_seed(seed: [u8; 4]) -> Self {
         let mut sfmt = SFMT {
-            state:  [zero(); sfmt::SFMT_N],
+            state: [zero(); sfmt::SFMT_N],
             idx: 0,
         };
         let seed = unsafe { *(seed.as_ptr() as *const u32) };
@@ -95,7 +95,7 @@ impl RngCore for SFMT {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::{FromEntropy, Rng};
+    use rand::{Rng, SeedableRng};
 
     #[test]
     fn random() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,19 +4,21 @@
 //! [stable SIMD]: https://github.com/rust-lang/rfcs/blob/master/text/2325-stable-simd.md
 //!
 //! ```
-//! use rand::prelude::*;
-//! let mut rng = sfmt::SFMT::from_entropy();
-//! let r = rng.gen::<u32>();
+//! use rand_core::{RngCore, SeedableRng};
+//! let mut rng = sfmt::SFMT::seed_from_u64(42);
+//! let r = rng.next_u32();
 //! println!("random u32 number = {}", r);
 //! ```
 
 mod packed;
 mod sfmt;
+#[cfg(feature = "thread")]
 mod thread_rng;
 
 use rand_core::{impls, Error, RngCore, SeedableRng};
 
 use self::packed::*;
+#[cfg(feature = "thread")]
 pub use self::thread_rng::{thread_rng, ThreadRng};
 
 /// State of SFMT
@@ -95,16 +97,16 @@ impl RngCore for SFMT {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::{Rng, SeedableRng};
+    use rand_core::{RngCore, SeedableRng};
 
     #[test]
     fn random() {
-        let mut rng = SFMT::from_entropy();
+        let mut rng = SFMT::seed_from_u64(0);
         for _ in 0..sfmt::SFMT_N * 20 {
             // Generate many random numbers to test the overwrap
-            let r = rng.gen::<u64>();
+            let r = rng.next_u64();
             if r % 2 == 0 {
-                let _r = rng.gen::<u32>();
+                let _r = rng.next_u32();
             } // shift SFMT.idx randomly
         }
     }

--- a/src/sfmt.rs
+++ b/src/sfmt.rs
@@ -113,7 +113,7 @@ pub fn sfmt_init_gen_rand(sfmt: &mut SFMT, seed: u32) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::SeedableRng;
+    use rand_core::SeedableRng;
     use std::{fs, io, io::BufRead};
 
     fn split(a: i32x4) -> (u32, u32, u32, u32) {
@@ -130,7 +130,8 @@ mod tests {
                     .map(|s| s.trim().parse().unwrap())
                     .collect();
                 new(vals[0], vals[1], vals[2], vals[3])
-            }).collect())
+            })
+            .collect())
     }
 
     #[test]

--- a/src/thread_rng.rs
+++ b/src/thread_rng.rs
@@ -2,8 +2,7 @@
 
 use super::SFMT;
 
-use rand::FromEntropy;
-use rand_core::{Error, RngCore};
+use rand::{Error, RngCore, SeedableRng};
 use std::cell::RefCell;
 use std::rc::Rc;
 

--- a/tests/sfmt.rs
+++ b/tests/sfmt.rs
@@ -1,7 +1,4 @@
-extern crate rand;
-extern crate sfmt;
-
-use rand::{RngCore, SeedableRng};
+use rand_core::{RngCore, SeedableRng};
 use sfmt::*;
 use std::io::Read;
 

--- a/tests/thread_rng.rs
+++ b/tests/thread_rng.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "thread")]
+#![cfg(feature = "thread_rng")]
 
 use rand::Rng;
 use std::thread;

--- a/tests/thread_rng.rs
+++ b/tests/thread_rng.rs
@@ -1,5 +1,4 @@
-extern crate rand;
-extern crate sfmt;
+#![cfg(feature = "thread")]
 
 use rand::Rng;
 use std::thread;


### PR DESCRIPTION
I'm not entirely sure this is useful to anyone else, however I thought it was and so thought I should offer the changes upstream. I have split all the changes into two pull requests with #26 being just the updates to rand and rand_core which is probably less objectionable, and this being the thread feature.

Running the tests with the thread feature requires the command
```sh
cargo test --features thread
```
which has been added to the CI
